### PR TITLE
Five new features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ build-*/
 # other
 build.sh
 compile_commands.json
+
+# CLion
+/cmake-*/

--- a/src/hacks/Global/CompactViews.cpp
+++ b/src/hacks/Global/CompactViews.cpp
@@ -9,13 +9,15 @@ namespace eclipse::hacks::Global {
 
     class CompactViews : public hack::Hack {
         void init() override {
+        	config::setIfEmpty("global.compacteditorlevels", false);
+        	config::setIfEmpty("global.compactprofilecomments", false);
             auto tab = gui::MenuTab::find("Global");
             tab->addToggle("Compact Editor Levels", "global.compacteditorlevels")
                 ->handleKeybinds()
-                ->setDescription("Enables the compact view when browsing custom editor levels. Adapted from code by Cvolton.");
+                ->setDescription("Enables the compact view when browsing custom editor levels. Adapted from code by Cvolton. (Created by RayDeeUx)");
             tab->addToggle("Compact Profile Comments", "global.compactprofilecomments")
                 ->handleKeybinds()
-                ->setDescription("Enables the compact view when viewing profile comments. Adapted from code by Cvolton.");
+                ->setDescription("Enables the compact view when viewing profile comments. Adapted from code by Cvolton. (Created by RayDeeUx)");
         }
 
         [[nodiscard]] const char* getId() const override { return "Compact Views"; }
@@ -29,11 +31,12 @@ namespace eclipse::hacks::Global {
     	and now reused for profile comments yayy
     	proof of consent of code reuse: https://discord.com/channels/911701438269386882/911702535373475870/1220117410988953762
     	and now it finds a new home in eclipsemenu
+    	-- raydeeux
     	*/
         static CustomListView* create(cocos2d::CCArray* a, TableViewCellDelegate* b, float c, float d, int e, BoomListType f, float g) {
-            if (f == BoomListType::Level2 && config::get<bool>("global.compacteditorlevels")) {
+            if (f == BoomListType::Level2 && config::get<bool>("global.compacteditorlevels", true)) {
                 f = BoomListType::Level4; // Level4 = compact level view
-            } else if (f == BoomListType::Comment4 && config::get<bool>("global.compactprofilecomments")) {
+            } else if (f == BoomListType::Comment4 && config::get<bool>("global.compactprofilecomments", true)) {
                 f = BoomListType::Comment2; // Comment2 = compact comment view
             }
             return CustomListView::create(a, b, c, d, e, f, g);
@@ -43,7 +46,7 @@ namespace eclipse::hacks::Global {
 	class $modify(EclipseLevelCell, LevelCell) {
 		void onClick(CCObject* sender) {
 			// hooking this function is necessary in order for the "view" button to work while compact mode is active in "my levels"
-			if (this->m_level->m_levelType == GJLevelType::Editor && config::get<bool>("global.compacteditorlevels")) {
+			if (this->m_level->m_levelType == GJLevelType::Editor && config::get<bool>("global.compacteditorlevels", true)) {
 				const auto scene = cocos2d::CCScene::create();
 				scene->addChild(EditLevelLayer::create(m_level));
 				cocos2d::CCDirector::sharedDirector()->replaceScene(cocos2d::CCTransitionFade::create(0.5f, scene));
@@ -51,12 +54,13 @@ namespace eclipse::hacks::Global {
 		}
 		void loadLocalLevelCell() {
 			LevelCell::loadLocalLevelCell();
-			if (!config::get<bool>("global.compacteditorlevels")) { return; }
-			if (const auto localLevelname = geode::cast::typeinfo_cast<cocos2d::CCLabelBMFont*>(getChildByIDRecursive("level-name"))) {
-				localLevelname->limitLabelWidth(200.f, .6f, .01f);
-			}
-			if (const auto mainLayer = geode::cast::typeinfo_cast<CCLayer*>(getChildByIDRecursive("main-layer"))) {
-				mainLayer->setPositionY(-3.5f);
+			if (config::get<bool>("global.compacteditorlevels", true)) {
+				if (const auto localLevelname = geode::cast::typeinfo_cast<cocos2d::CCLabelBMFont*>(getChildByIDRecursive("level-name"))) {
+					localLevelname->limitLabelWidth(200.f, .6f, .01f);
+				}
+				if (const auto mainLayer = geode::cast::typeinfo_cast<CCLayer*>(getChildByIDRecursive("main-layer"))) {
+					mainLayer->setPositionY(-3.5f);
+				}
 			}
 		}
 	};

--- a/src/hacks/Global/CompactViews.cpp
+++ b/src/hacks/Global/CompactViews.cpp
@@ -7,60 +7,57 @@
 
 namespace eclipse::hacks::Global {
 
-    class CompactViews : public hack::Hack {
-        void init() override {
-        	config::setIfEmpty("global.compacteditorlevels", false);
-        	config::setIfEmpty("global.compactprofilecomments", false);
-            auto tab = gui::MenuTab::find("Global");
-            tab->addToggle("Compact Editor Levels", "global.compacteditorlevels")
-                ->handleKeybinds()
-                ->setDescription("Enables the compact view when browsing custom editor levels. Adapted from code by Cvolton. (Created by RayDeeUx)");
-            tab->addToggle("Compact Profile Comments", "global.compactprofilecomments")
-                ->handleKeybinds()
-                ->setDescription("Enables the compact view when viewing profile comments. Adapted from code by Cvolton. (Created by RayDeeUx)");
-        }
+	class CompactViews : public hack::Hack {
+		void init() override {
+			config::setIfEmpty("global.compacteditorlevels", false);
+			config::setIfEmpty("global.compactprofilecomments", false);
+			auto tab = gui::MenuTab::find("Global");
+			tab->addToggle("Compact Editor Levels", "global.compacteditorlevels")
+				->handleKeybinds()
+				->setDescription("Enables the compact view when browsing custom editor levels. Adapted from code by Cvolton. (Created by RayDeeUx)");
+			tab->addToggle("Compact Profile Comments", "global.compactprofilecomments")
+				->handleKeybinds()
+				->setDescription("Enables the compact view when viewing profile comments. Adapted from code by Cvolton. (Created by RayDeeUx)");
+		}
 
-        [[nodiscard]] const char* getId() const override { return "Compact Views"; }
-    };
+		[[nodiscard]] const char* getId() const override { return "Compact Views"; }
+	};
 
-    REGISTER_HACK(CompactViews);
+	REGISTER_HACK(CompactViews);
 
-    class $modify(EclipseCustomListView, CustomListView) {
-    	/*
-    	original code by cvolton, re-used for "my levels" list
-    	and now reused for profile comments yayy
-    	proof of consent of code reuse: https://discord.com/channels/911701438269386882/911702535373475870/1220117410988953762
-    	and now it finds a new home in eclipsemenu
-    	-- raydeeux
-    	*/
-        static CustomListView* create(cocos2d::CCArray* a, TableViewCellDelegate* b, float c, float d, int e, BoomListType f, float g) {
-            if (f == BoomListType::Level2 && config::get<bool>("global.compacteditorlevels", true)) {
-                f = BoomListType::Level4; // Level4 = compact level view
-            } else if (f == BoomListType::Comment4 && config::get<bool>("global.compactprofilecomments", true)) {
-                f = BoomListType::Comment2; // Comment2 = compact comment view
-            }
-            return CustomListView::create(a, b, c, d, e, f, g);
-        }
-    };
+	class $modify(EclipseCustomListView, CustomListView) {
+		/*
+		original code by cvolton, re-used for "my levels" list
+		and now reused for profile comments yayy
+		proof of consent of code reuse: https://discord.com/channels/911701438269386882/911702535373475870/1220117410988953762
+		and now it finds a new home in eclipsemenu
+		-- raydeeux
+		*/
+		static CustomListView* create(cocos2d::CCArray* a, TableViewCellDelegate* b, float c, float d, int e, BoomListType f, float g) {
+			if (f == BoomListType::Level2 && config::get<bool>("global.compacteditorlevels", false))
+				f = BoomListType::Level4; // Level4 = compact level view
+			else if (f == BoomListType::Comment4 && config::get<bool>("global.compactprofilecomments", false))
+				f = BoomListType::Comment2; // Comment2 = compact comment view
+			return CustomListView::create(a, b, c, d, e, f, g);
+		}
+	};
 
 	class $modify(EclipseLevelCell, LevelCell) {
 		void onClick(CCObject* sender) {
 			// hooking this function is necessary in order for the "view" button to work while compact mode is active in "my levels"
-			if (this->m_level->m_levelType == GJLevelType::Editor && config::get<bool>("global.compacteditorlevels", true)) {
+			if (this->m_level->m_levelType == GJLevelType::Editor && config::get<bool>("global.compacteditorlevels", false)) {
 				const auto scene = cocos2d::CCScene::create();
 				scene->addChild(EditLevelLayer::create(m_level));
 				cocos2d::CCDirector::sharedDirector()->replaceScene(cocos2d::CCTransitionFade::create(0.5f, scene));
-			} else { LevelCell::onClick(sender); }
+			} else LevelCell::onClick(sender);
 		}
 		void loadLocalLevelCell() {
 			LevelCell::loadLocalLevelCell();
-			if (config::get<bool>("global.compacteditorlevels", true)) {
-				if (const auto localLevelname = geode::cast::typeinfo_cast<cocos2d::CCLabelBMFont*>(getChildByIDRecursive("level-name"))) {
+			if (config::get<bool>("global.compacteditorlevels", false)) {
+				if (const auto localLevelname = geode::cast::typeinfo_cast<cocos2d::CCLabelBMFont*>(getChildByIDRecursive("level-name")))
 					localLevelname->limitLabelWidth(200.f, .6f, .01f);
-				}
-				if (const auto mainLayer = geode::cast::typeinfo_cast<CCLayer*>(getChildByIDRecursive("main-layer"))) {
+				if (const auto mainLayer = geode::cast::typeinfo_cast<CCLayer*>(getChildByIDRecursive("main-layer")))
 					mainLayer->setPositionY(-3.5f);
-				}
 			}
 		}
 	};

--- a/src/hacks/Global/CompactViews.cpp
+++ b/src/hacks/Global/CompactViews.cpp
@@ -1,0 +1,63 @@
+#include <modules/gui/gui.hpp>
+#include <modules/hack/hack.hpp>
+#include <modules/config/config.hpp>
+
+#include <Geode/modify/CustomListView.hpp>
+#include <Geode/modify/LevelCell.hpp>
+
+namespace eclipse::hacks::Global {
+
+    class CompactViews : public hack::Hack {
+        void init() override {
+            auto tab = gui::MenuTab::find("Global");
+            tab->addToggle("Compact Editor Levels", "global.compacteditorlevels")
+                ->handleKeybinds()
+                ->setDescription("Enables the compact view when browsing custom editor levels. Adapted from code by Cvolton.");
+            tab->addToggle("Compact Profile Comments", "global.compactprofilecomments")
+                ->handleKeybinds()
+                ->setDescription("Enables the compact view when viewing profile comments. Adapted from code by Cvolton.");
+        }
+
+        [[nodiscard]] const char* getId() const override { return "Compact Views"; }
+    };
+
+    REGISTER_HACK(CompactViews);
+
+    class $modify(EclipseCustomListView, CustomListView) {
+    	/*
+    	original code by cvolton, re-used for "my levels" list
+    	and now reused for profile comments yayy
+    	proof of consent of code reuse: https://discord.com/channels/911701438269386882/911702535373475870/1220117410988953762
+    	and now it finds a new home in eclipsemenu
+    	*/
+        static CustomListView* create(cocos2d::CCArray* a, TableViewCellDelegate* b, float c, float d, int e, BoomListType f, float g) {
+            if (f == BoomListType::Level2 && config::get<bool>("global.compacteditorlevels")) {
+                f = BoomListType::Level4; // Level4 = compact level view
+            } else if (f == BoomListType::Comment4 && config::get<bool>("global.compactprofilecomments")) {
+                f = BoomListType::Comment2; // Comment2 = compact comment view
+            }
+            return CustomListView::create(a, b, c, d, e, f, g);
+        }
+    };
+
+	class $modify(EclipseLevelCell, LevelCell) {
+		void onClick(CCObject* sender) {
+			// hooking this function is necessary in order for the "view" button to work while compact mode is active in "my levels"
+			if (this->m_level->m_levelType == GJLevelType::Editor && config::get<bool>("global.compacteditorlevels")) {
+				const auto scene = cocos2d::CCScene::create();
+				scene->addChild(EditLevelLayer::create(m_level));
+				cocos2d::CCDirector::sharedDirector()->replaceScene(cocos2d::CCTransitionFade::create(0.5f, scene));
+			} else { LevelCell::onClick(sender); }
+		}
+		void loadLocalLevelCell() {
+			LevelCell::loadLocalLevelCell();
+			if (!config::get<bool>("global.compacteditorlevels")) { return; }
+			if (const auto localLevelname = geode::cast::typeinfo_cast<cocos2d::CCLabelBMFont*>(getChildByIDRecursive("level-name"))) {
+				localLevelname->limitLabelWidth(200.f, .6f, .01f);
+			}
+			if (const auto mainLayer = geode::cast::typeinfo_cast<CCLayer*>(getChildByIDRecursive("main-layer"))) {
+				mainLayer->setPositionY(-3.5f);
+			}
+		}
+	};
+}

--- a/src/hacks/Global/CompactViews.cpp
+++ b/src/hacks/Global/CompactViews.cpp
@@ -9,8 +9,6 @@ namespace eclipse::hacks::Global {
 
 	class CompactViews : public hack::Hack {
 		void init() override {
-			config::setIfEmpty("global.compacteditorlevels", false);
-			config::setIfEmpty("global.compactprofilecomments", false);
 			auto tab = gui::MenuTab::find("Global");
 			tab->addToggle("Compact Editor Levels", "global.compacteditorlevels")
 				->handleKeybinds()

--- a/src/hacks/Level/HideLevelCompleteVFX.cpp
+++ b/src/hacks/Level/HideLevelCompleteVFX.cpp
@@ -9,7 +9,6 @@ namespace eclipse::hacks::Level {
 
 	class HideLevelCompleteVFX : public hack::Hack {
 		void init() override {
-			config::setIfEmpty("level.hidelevelcomplete", false);
 			auto tab = gui::MenuTab::find("Level");
 			tab->addToggle("Hide Level Complete VFX", "level.hidelevelcomplete")
 				->setDescription("Hides the explosion and fireworks seen when completing a level. (Does not hide particles.) (Created by RayDeeUx)")

--- a/src/hacks/Level/HideLevelCompleteVFX.cpp
+++ b/src/hacks/Level/HideLevelCompleteVFX.cpp
@@ -8,9 +8,10 @@ namespace eclipse::hacks::Level {
 
     class HideLevelCompleteVFX : public hack::Hack {
         void init() override {
+            config::setIfEmpty("level.hidelevelcomplete", false);
             auto tab = gui::MenuTab::find("Level");
             tab->addToggle("Hide Level Complete VFX", "level.hidelevelcomplete")
-                ->setDescription("Hides the explosion and fireworks seen when completing a level. (Does not hide particles.)")
+                ->setDescription("Hides the explosion and fireworks seen when completing a level. (Does not hide particles.) (Created by RayDeeUx)")
                 ->handleKeybinds();
         }
 
@@ -31,20 +32,32 @@ namespace eclipse::hacks::Level {
                     ccCircleWave->setVisible(false);
                 }
             }
+            CCLayer* forCircleWaveLightFlash = nullptr;
             if (const auto mainNode = getChildByIDRecursive("main-node")) {
                 for (CCNode* mainNodeChild : geode::cocos::CCArrayExt<CCNode*>(mainNode->getChildren())) {
                     if (const auto whereEverythingIs = geode::cast::typeinfo_cast<CCLayer*>(mainNodeChild)) {
-                        for (CCNode* childTwo : geode::cocos::CCArrayExt<CCNode*>(whereEverythingIs->getChildren())) {
-                            if (const auto ccCircleWave = geode::cast::typeinfo_cast<CCCircleWave*>(childTwo)) {
-                                ccCircleWave->setVisible(false);
-                            } else if (const auto ccLightFlash = geode::cast::typeinfo_cast<CCLightFlash*>(childTwo)) {
-                                ccLightFlash->setVisible(false);
-                            }
-                        }
+                        forCircleWaveLightFlash = whereEverythingIs;
+                        break;
+                    }
+                }
+            }
+            if (forCircleWaveLightFlash) {
+                for (CCNode* childTwo : geode::cocos::CCArrayExt<CCNode*>(forCircleWaveLightFlash->getChildren())) {
+                    if (const auto ccCircleWave = geode::cast::typeinfo_cast<CCCircleWave*>(childTwo)) {
+                        ccCircleWave->setVisible(false);
+                    } else if (const auto ccLightFlash = geode::cast::typeinfo_cast<CCLightFlash*>(childTwo)) {
+                        ccLightFlash->setVisible(false);
                     }
                 }
             }
         }
+        /*
+        unfortunately TodoReturn spawnCircle() and TodoReturn spawnFirework()
+        are unavailable for hooking, so i need to improvise.
+        also, while it's more performant to hook showCompleteText and showCompleteEffect,
+        neither of these two hooks cover all possible ccCircleWave/ccLightFlash nodes.
+        -- raydeeux
+        */
         void onQuit() {
             m_fields->isLevelComplete = false;
             PlayLayer::onQuit();

--- a/src/hacks/Level/HideLevelCompleteVFX.cpp
+++ b/src/hacks/Level/HideLevelCompleteVFX.cpp
@@ -6,69 +6,70 @@
 
 namespace eclipse::hacks::Level {
 
-    class HideLevelCompleteVFX : public hack::Hack {
-        void init() override {
-            config::setIfEmpty("level.hidelevelcomplete", false);
-            auto tab = gui::MenuTab::find("Level");
-            tab->addToggle("Hide Level Complete VFX", "level.hidelevelcomplete")
-                ->setDescription("Hides the explosion and fireworks seen when completing a level. (Does not hide particles.) (Created by RayDeeUx)")
-                ->handleKeybinds();
-        }
+	class HideLevelCompleteVFX : public hack::Hack {
+		void init() override {
+			config::setIfEmpty("level.hidelevelcomplete", false);
+			auto tab = gui::MenuTab::find("Level");
+			tab->addToggle("Hide Level Complete VFX", "level.hidelevelcomplete")
+				->setDescription("Hides the explosion and fireworks seen when completing a level. (Does not hide particles.) (Created by RayDeeUx)")
+				->handleKeybinds();
+		}
 
-        [[nodiscard]] const char* getId() const override { return "Hide Level Complete VFX"; }
-    };
+		[[nodiscard]] const char* getId() const override { return "Hide Level Complete VFX"; }
+	};
 
-    REGISTER_HACK(HideLevelCompleteVFX)
+	REGISTER_HACK(HideLevelCompleteVFX)
 
-    class $modify(EclipsePlayLayer, PlayLayer) {
-        struct Fields {
-            bool isLevelComplete = false;
-        };
-        void eclipseHideVFX() {
-            if (!m_fields->isLevelComplete) { return; }
-            for (unsigned int i = getChildrenCount(); i-- > 0; ) {
-                auto theObject = getChildren()->objectAtIndex(i);
-                if (const auto ccCircleWave = geode::cast::typeinfo_cast<CCCircleWave*>(theObject)) {
-                    ccCircleWave->setVisible(false);
-                }
-            }
-            if (const auto mainNode = getChildByIDRecursive("main-node")) {
-                for (CCNode* mainNodeChild : geode::cocos::CCArrayExt<CCNode*>(mainNode->getChildren())) {
-                    if (const auto whereEverythingIs = geode::cast::typeinfo_cast<CCLayer*>(mainNodeChild)) {
-                        for (CCNode* childTwo : geode::cocos::CCArrayExt<CCNode*>(whereEverythingIs->getChildren())) {
-                            if (const auto ccCircleWave = geode::cast::typeinfo_cast<CCCircleWave*>(childTwo)) {
-                                ccCircleWave->setVisible(false);
-                            } else if (const auto ccLightFlash = geode::cast::typeinfo_cast<CCLightFlash*>(childTwo)) {
-                                ccLightFlash->setVisible(false);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        /*
-        unfortunately TodoReturn spawnCircle() and TodoReturn spawnFirework()
-        are unavailable for hooking, so i need to improvise.
-        also, while it's more performant to hook showCompleteText and showCompleteEffect,
-        neither of these two hooks cover all possible ccCircleWave/ccLightFlash nodes.
-        -- raydeeux
-        */
-        void onQuit() {
-            m_fields->isLevelComplete = false;
-            PlayLayer::onQuit();
-        }
-        void postUpdate(float p0) {
-            PlayLayer::postUpdate(p0);
-            if (config::get<bool>("level.hidelevelcomplete", true) && m_fields->isLevelComplete) {
-                EclipsePlayLayer::eclipseHideVFX();
-            }
-        }
-        void levelComplete() {
-            PlayLayer::levelComplete();
-            if (config::get<bool>("level.hidelevelcomplete", true)) {
-                m_fields->isLevelComplete = true;
-                EclipsePlayLayer::eclipseHideVFX();
-            }
-        }
-    };
+	class $modify(EclipsePlayLayer, PlayLayer) {
+		struct Fields {
+			bool isLevelComplete = false;
+		};
+		void eclipseHideVFX() {
+			if (!m_fields->isLevelComplete) return;
+			if (getParent()->getChildByID("PauseLayer")) return;
+			for (unsigned int i = getChildrenCount(); i-- > 0; ) {
+				auto theObject = getChildren()->objectAtIndex(i);
+				if (const auto ccCircleWave = geode::cast::typeinfo_cast<CCCircleWave*>(theObject)) {
+					ccCircleWave->setVisible(false);
+				}
+			}
+			if (const auto mainNode = getChildByIDRecursive("main-node")) {
+				for (CCNode* mainNodeChild : geode::cocos::CCArrayExt<CCNode*>(mainNode->getChildren())) {
+					if (const auto whereEverythingIs = geode::cast::typeinfo_cast<CCLayer*>(mainNodeChild)) {
+						for (CCNode* childTwo : geode::cocos::CCArrayExt<CCNode*>(whereEverythingIs->getChildren())) {
+							if (const auto ccCircleWave = geode::cast::typeinfo_cast<CCCircleWave*>(childTwo)) {
+								ccCircleWave->setVisible(false);
+							} else if (const auto ccLightFlash = geode::cast::typeinfo_cast<CCLightFlash*>(childTwo)) {
+								ccLightFlash->setVisible(false);
+							}
+						}
+					}
+				}
+			}
+		}
+		/*
+		unfortunately TodoReturn spawnCircle() and TodoReturn spawnFirework()
+		are unavailable for hooking, so i need to improvise.
+		also, while it's more performant to hook showCompleteText and showCompleteEffect,
+		neither of these two hooks cover all possible ccCircleWave/ccLightFlash nodes.
+		-- raydeeux
+		*/
+		void onQuit() {
+			m_fields->isLevelComplete = false;
+			PlayLayer::onQuit();
+		}
+		void postUpdate(float p0) {
+			PlayLayer::postUpdate(p0);
+			if (config::get<bool>("level.hidelevelcomplete", false) && m_fields->isLevelComplete && !getParent()->getChildByID("PauseLayer")) {
+				EclipsePlayLayer::eclipseHideVFX();
+			}
+		}
+		void levelComplete() {
+			PlayLayer::levelComplete();
+			if (config::get<bool>("level.hidelevelcomplete", false)) {
+				m_fields->isLevelComplete = true;
+				EclipsePlayLayer::eclipseHideVFX();
+			}
+		}
+	};
 }

--- a/src/hacks/Level/HideLevelCompleteVFX.cpp
+++ b/src/hacks/Level/HideLevelCompleteVFX.cpp
@@ -1,0 +1,64 @@
+#include <modules/gui/gui.hpp>
+#include <modules/hack/hack.hpp>
+#include <modules/config/config.hpp>
+
+#include <Geode/modify/PlayLayer.hpp>
+
+namespace eclipse::hacks::Level {
+
+    class HideLevelCompleteVFX : public hack::Hack {
+        void init() override {
+            auto tab = gui::MenuTab::find("Level");
+            tab->addToggle("Hide Level Complete VFX", "level.hidelevelcomplete")
+                ->setDescription("Hides the explosion and fireworks seen when completing a level. (Does not hide particles.)")
+                ->handleKeybinds();
+        }
+
+        [[nodiscard]] const char* getId() const override { return "Hide Level Complete VFX"; }
+    };
+
+    REGISTER_HACK(HideLevelCompleteVFX)
+
+    class $modify(EclipsePlayLayer, PlayLayer) {
+        struct Fields {
+            bool isLevelComplete = false;
+        };
+        void eclipseHideVFX() {
+            if (!config::get<bool>("level.hidelevelcomplete") || !m_fields->isLevelComplete) { return; }
+            for (unsigned int i = getChildrenCount(); i-- > 0; ) {
+                auto theObject = getChildren()->objectAtIndex(i);
+                if (const auto ccCircleWave = geode::cast::typeinfo_cast<CCCircleWave*>(theObject)) {
+                    ccCircleWave->setVisible(false);
+                }
+            }
+            if (const auto mainNode = getChildByIDRecursive("main-node")) {
+                for (CCNode* mainNodeChild : geode::cocos::CCArrayExt<CCNode*>(mainNode->getChildren())) {
+                    if (const auto whereEverythingIs = geode::cast::typeinfo_cast<CCLayer*>(mainNodeChild)) {
+                        for (CCNode* childTwo : geode::cocos::CCArrayExt<CCNode*>(whereEverythingIs->getChildren())) {
+                            if (const auto ccCircleWave = geode::cast::typeinfo_cast<CCCircleWave*>(childTwo)) {
+                                ccCircleWave->setVisible(false);
+                            } else if (const auto ccLightFlash = geode::cast::typeinfo_cast<CCLightFlash*>(childTwo)) {
+                                ccLightFlash->setVisible(false);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        void onQuit() {
+            m_fields->isLevelComplete = false;
+            PlayLayer::onQuit();
+        }
+        void postUpdate(float p0) {
+            PlayLayer::postUpdate(p0);
+            if (!config::get<bool>("level.hidelevelcomplete") || !m_fields->isLevelComplete) { return; }
+            EclipsePlayLayer::eclipseHideVFX();
+        }
+        void levelComplete() {
+            PlayLayer::levelComplete();
+            if (!config::get<bool>("level.hidelevelcomplete")) { return; }
+            m_fields->isLevelComplete = true;
+            EclipsePlayLayer::eclipseHideVFX();
+        }
+    };
+}

--- a/src/hacks/Level/HideLevelCompleteVFX.cpp
+++ b/src/hacks/Level/HideLevelCompleteVFX.cpp
@@ -25,28 +25,23 @@ namespace eclipse::hacks::Level {
             bool isLevelComplete = false;
         };
         void eclipseHideVFX() {
-            if (!config::get<bool>("level.hidelevelcomplete") || !m_fields->isLevelComplete) { return; }
+            if (!m_fields->isLevelComplete) { return; }
             for (unsigned int i = getChildrenCount(); i-- > 0; ) {
                 auto theObject = getChildren()->objectAtIndex(i);
                 if (const auto ccCircleWave = geode::cast::typeinfo_cast<CCCircleWave*>(theObject)) {
                     ccCircleWave->setVisible(false);
                 }
             }
-            CCLayer* forCircleWaveLightFlash = nullptr;
             if (const auto mainNode = getChildByIDRecursive("main-node")) {
                 for (CCNode* mainNodeChild : geode::cocos::CCArrayExt<CCNode*>(mainNode->getChildren())) {
                     if (const auto whereEverythingIs = geode::cast::typeinfo_cast<CCLayer*>(mainNodeChild)) {
-                        forCircleWaveLightFlash = whereEverythingIs;
-                        break;
-                    }
-                }
-            }
-            if (forCircleWaveLightFlash) {
-                for (CCNode* childTwo : geode::cocos::CCArrayExt<CCNode*>(forCircleWaveLightFlash->getChildren())) {
-                    if (const auto ccCircleWave = geode::cast::typeinfo_cast<CCCircleWave*>(childTwo)) {
-                        ccCircleWave->setVisible(false);
-                    } else if (const auto ccLightFlash = geode::cast::typeinfo_cast<CCLightFlash*>(childTwo)) {
-                        ccLightFlash->setVisible(false);
+                        for (CCNode* childTwo : geode::cocos::CCArrayExt<CCNode*>(whereEverythingIs->getChildren())) {
+                            if (const auto ccCircleWave = geode::cast::typeinfo_cast<CCCircleWave*>(childTwo)) {
+                                ccCircleWave->setVisible(false);
+                            } else if (const auto ccLightFlash = geode::cast::typeinfo_cast<CCLightFlash*>(childTwo)) {
+                                ccLightFlash->setVisible(false);
+                            }
+                        }
                     }
                 }
             }
@@ -64,14 +59,16 @@ namespace eclipse::hacks::Level {
         }
         void postUpdate(float p0) {
             PlayLayer::postUpdate(p0);
-            if (!config::get<bool>("level.hidelevelcomplete") || !m_fields->isLevelComplete) { return; }
-            EclipsePlayLayer::eclipseHideVFX();
+            if (config::get<bool>("level.hidelevelcomplete", true) && m_fields->isLevelComplete) {
+                EclipsePlayLayer::eclipseHideVFX();
+            }
         }
         void levelComplete() {
             PlayLayer::levelComplete();
-            if (!config::get<bool>("level.hidelevelcomplete")) { return; }
-            m_fields->isLevelComplete = true;
-            EclipsePlayLayer::eclipseHideVFX();
+            if (config::get<bool>("level.hidelevelcomplete", true)) {
+                m_fields->isLevelComplete = true;
+                EclipsePlayLayer::eclipseHideVFX();
+            }
         }
     };
 }

--- a/src/hacks/Level/MuteLevelSFX.cpp
+++ b/src/hacks/Level/MuteLevelSFX.cpp
@@ -1,0 +1,26 @@
+#include <modules/gui/gui.hpp>
+#include <modules/hack/hack.hpp>
+#include <modules/config/config.hpp>
+
+#include <Geode/modify/EffectGameObject.hpp>
+
+namespace eclipse::hacks::Level {
+
+    class MuteLevelSFX : public hack::Hack {
+        void init() override {
+            auto tab = gui::MenuTab::find("Level");
+            tab->addToggle("Mute Level SFX", "level.mutelevelsfx")->handleKeybinds();
+        }
+
+        [[nodiscard]] const char* getId() const override { return "Mute Level SFX"; }
+    };
+
+    REGISTER_HACK(MuteLevelSFX)
+
+    class $modify(EffectGameObject) {
+        void triggerObject(GJBaseGameLayer* gjbgl, int p1, gd::vector<int> const* p2) {
+            if (!PlayLayer::get() || !config::get<bool>("level.mutelevelsfx")) { return EffectGameObject::triggerObject(gjbgl, p1, p2); }
+            if (this->m_objectID != 3602 && this->m_objectID != 3603) { return EffectGameObject::triggerObject(gjbgl, p1, p2); }
+        }
+    };
+}

--- a/src/hacks/Level/MuteLevelSFX.cpp
+++ b/src/hacks/Level/MuteLevelSFX.cpp
@@ -8,8 +8,11 @@ namespace eclipse::hacks::Level {
 
     class MuteLevelSFX : public hack::Hack {
         void init() override {
+            config::setIfEmpty("level.mutelevelsfx", false);
             auto tab = gui::MenuTab::find("Level");
-            tab->addToggle("Mute Level SFX", "level.mutelevelsfx")->handleKeybinds();
+            tab->addToggle("Mute Level SFX", "level.mutelevelsfx")
+                ->setDescription("Disables SFX/Edit SFX triggers. (Created by RayDeeUx)")
+                ->handleKeybinds();
         }
 
         [[nodiscard]] const char* getId() const override { return "Mute Level SFX"; }

--- a/src/hacks/Level/MuteLevelSFX.cpp
+++ b/src/hacks/Level/MuteLevelSFX.cpp
@@ -6,24 +6,26 @@
 
 namespace eclipse::hacks::Level {
 
-    class MuteLevelSFX : public hack::Hack {
-        void init() override {
-            config::setIfEmpty("level.mutelevelsfx", false);
-            auto tab = gui::MenuTab::find("Level");
-            tab->addToggle("Mute Level SFX", "level.mutelevelsfx")
-                ->setDescription("Disables SFX/Edit SFX triggers. (Created by RayDeeUx)")
-                ->handleKeybinds();
-        }
+	class MuteLevelSFX : public hack::Hack {
+		void init() override {
+			config::setIfEmpty("level.mutelevelsfx", false);
+			auto tab = gui::MenuTab::find("Level");
+			tab->addToggle("Mute Level SFX", "level.mutelevelsfx")
+				->setDescription("Disables SFX/Edit SFX triggers. (Created by RayDeeUx)")
+				->handleKeybinds();
+		}
 
-        [[nodiscard]] const char* getId() const override { return "Mute Level SFX"; }
-    };
+		[[nodiscard]] const char* getId() const override { return "Mute Level SFX"; }
+	};
 
-    REGISTER_HACK(MuteLevelSFX)
+	REGISTER_HACK(MuteLevelSFX)
 
-    class $modify(EffectGameObject) {
-        void triggerObject(GJBaseGameLayer* gjbgl, int p1, gd::vector<int> const* p2) {
-            if (!PlayLayer::get() || !config::get<bool>("level.mutelevelsfx", false)) { return EffectGameObject::triggerObject(gjbgl, p1, p2); }
-            if (this->m_objectID != 3602 && this->m_objectID != 3603) { return EffectGameObject::triggerObject(gjbgl, p1, p2); }
-        }
-    };
+	class $modify(EffectGameObject) {
+		void triggerObject(GJBaseGameLayer* gjbgl, int p1, gd::vector<int> const* p2) {
+			if (!PlayLayer::get() || !config::get<bool>("level.mutelevelsfx", false))
+				return EffectGameObject::triggerObject(gjbgl, p1, p2);
+			if (this->m_objectID != 3602 && this->m_objectID != 3603)
+				return EffectGameObject::triggerObject(gjbgl, p1, p2);
+		}
+	};
 }

--- a/src/hacks/Level/MuteLevelSFX.cpp
+++ b/src/hacks/Level/MuteLevelSFX.cpp
@@ -8,7 +8,6 @@ namespace eclipse::hacks::Level {
 
 	class MuteLevelSFX : public hack::Hack {
 		void init() override {
-			config::setIfEmpty("level.mutelevelsfx", false);
 			auto tab = gui::MenuTab::find("Level");
 			tab->addToggle("Mute Level SFX", "level.mutelevelsfx")
 				->setDescription("Disables SFX/Edit SFX triggers. (Created by RayDeeUx)")

--- a/src/hacks/Level/MuteLevelSFX.cpp
+++ b/src/hacks/Level/MuteLevelSFX.cpp
@@ -22,7 +22,7 @@ namespace eclipse::hacks::Level {
 
     class $modify(EffectGameObject) {
         void triggerObject(GJBaseGameLayer* gjbgl, int p1, gd::vector<int> const* p2) {
-            if (!PlayLayer::get() || !config::get<bool>("level.mutelevelsfx")) { return EffectGameObject::triggerObject(gjbgl, p1, p2); }
+            if (!PlayLayer::get() || !config::get<bool>("level.mutelevelsfx", false)) { return EffectGameObject::triggerObject(gjbgl, p1, p2); }
             if (this->m_objectID != 3602 && this->m_objectID != 3603) { return EffectGameObject::triggerObject(gjbgl, p1, p2); }
         }
     };

--- a/src/hacks/Player/MuteRewardsSFX.cpp
+++ b/src/hacks/Player/MuteRewardsSFX.cpp
@@ -8,8 +8,11 @@ namespace eclipse::hacks::Player {
 
     class MuteRewardsSFX : public hack::Hack {
         void init() override {
+            config::setIfEmpty("player.muterewardssfx", false);
             auto tab = gui::MenuTab::find("Player");
-            tab->addToggle("Mute Rewards SFX on Death", "player.muterewardssfx")->setDescription("Disables player death effect")->handleKeybinds();
+            tab->addToggle("Mute Rewards SFX on Death", "player.muterewardssfx")
+                ->setDescription("Disables all rewards SFX (orbs, diamonds, keys) when the player dies. (Created by RayDeeUx)")
+                ->handleKeybinds();
         }
 
         [[nodiscard]] const char* getId() const override { return "Mute Rewards SFX on Death"; }

--- a/src/hacks/Player/MuteRewardsSFX.cpp
+++ b/src/hacks/Player/MuteRewardsSFX.cpp
@@ -23,7 +23,7 @@ namespace eclipse::hacks::Player {
 
 	class $modify(FMODAudioEngine) {
 		struct Fields {
-			const std::string badSFX[4] = { "achievement_01.ogg", "magicExplosion.ogg", "gold02.ogg", "secretKey.ogg" };
+			const std::array<std::string, 4> badSFX = { "achievement_01.ogg", "magicExplosion.ogg", "gold02.ogg", "secretKey.ogg" };
 		};
 		static void onModify(auto& self) {
 			SAFE_PRIORITY("FMODAudioEngine::playEffect");

--- a/src/hacks/Player/MuteRewardsSFX.cpp
+++ b/src/hacks/Player/MuteRewardsSFX.cpp
@@ -1,3 +1,4 @@
+#include <iterator>
 #include <modules/gui/gui.hpp>
 #include <modules/hack/hack.hpp>
 #include <modules/config/config.hpp>
@@ -22,7 +23,7 @@ namespace eclipse::hacks::Player {
 
 	class $modify(FMODAudioEngine) {
 		struct Fields {
-			const std::set<std::string> badSFX = { "achievement_01.ogg", "magicExplosion.ogg", "gold02.ogg", "secretKey.ogg" };
+			const std::string badSFX[4] = { "achievement_01.ogg", "magicExplosion.ogg", "gold02.ogg", "secretKey.ogg" };
 		};
 		static void onModify(auto& self) {
 			SAFE_PRIORITY("FMODAudioEngine::playEffect");
@@ -33,7 +34,7 @@ namespace eclipse::hacks::Player {
 			if (!pl) { return FMODAudioEngine::sharedEngine()->playEffect(path, p1, p2, p3); } // play sfx if not in playlayer
 			bool isPlayerAlive = !pl->m_player1->m_isDead;
 			bool pauseLayerActive = cocos2d::CCDirector::get()->getRunningScene()->getChildByIDRecursive("PauseLayer");
-			bool notFoundInBadSFX = !m_fields->badSFX.contains(std::string(path));
+			bool notFoundInBadSFX = std::ranges::find(std::begin(m_fields->badSFX), std::end(m_fields->badSFX), std::string(path)) == std::end(m_fields->badSFX);
 			bool isSettingDisabled = !config::get<bool>("player.muterewardssfx", false);
 			// these bools could be in one if statement but are separated for readability
 			if (isSettingDisabled || pauseLayerActive || isPlayerAlive || notFoundInBadSFX) { FMODAudioEngine::sharedEngine()->playEffect(path, p1, p2, p3); }

--- a/src/hacks/Player/MuteRewardsSFX.cpp
+++ b/src/hacks/Player/MuteRewardsSFX.cpp
@@ -6,38 +6,38 @@
 
 namespace eclipse::hacks::Player {
 
-    class MuteRewardsSFX : public hack::Hack {
-        void init() override {
-            config::setIfEmpty("player.muterewardssfx", false);
-            auto tab = gui::MenuTab::find("Player");
-            tab->addToggle("Mute Rewards SFX on Death", "player.muterewardssfx")
-                ->setDescription("Disables all rewards SFX (orbs, diamonds, keys) when the player dies. (Created by RayDeeUx)")
-                ->handleKeybinds();
-        }
+	class MuteRewardsSFX : public hack::Hack {
+		void init() override {
+			config::setIfEmpty("player.muterewardssfx", false);
+			auto tab = gui::MenuTab::find("Player");
+			tab->addToggle("Mute Rewards SFX on Death", "player.muterewardssfx")
+				->setDescription("Disables all rewards SFX (orbs, diamonds, keys) when the player dies. (Created by RayDeeUx)")
+				->handleKeybinds();
+		}
 
-        [[nodiscard]] const char* getId() const override { return "Mute Rewards SFX on Death"; }
-    };
+		[[nodiscard]] const char* getId() const override { return "Mute Rewards SFX on Death"; }
+	};
 
-    REGISTER_HACK(MuteRewardsSFX)
+	REGISTER_HACK(MuteRewardsSFX)
 
-    class $modify(FMODAudioEngine) {
-        struct Fields {
-            const std::list<std::string> badSFX = { "achievement_01.ogg", "magicExplosion.ogg", "gold02.ogg", "secretKey.ogg" };
-        };
-        static void onModify(auto& self) {
-            SAFE_PRIORITY("FMODAudioEngine::playEffect");
-        }
+	class $modify(FMODAudioEngine) {
+		struct Fields {
+			const std::set<std::string> badSFX = { "achievement_01.ogg", "magicExplosion.ogg", "gold02.ogg", "secretKey.ogg" };
+		};
+		static void onModify(auto& self) {
+			SAFE_PRIORITY("FMODAudioEngine::playEffect");
+		}
 
-        void playEffect(gd::string path, float p1, float p2, float p3) {
-            auto pl = PlayLayer::get();
-            if (!pl) { return FMODAudioEngine::sharedEngine()->playEffect(path, p1, p2, p3); } // play sfx if not in playlayer
-            bool isPlayerAlive = !pl->m_player1->m_isDead;
-            bool pauseLayerActive = cocos2d::CCDirector::get()->getRunningScene()->getChildByIDRecursive("PauseLayer");
-            bool notFoundInBadSFX = std::find(m_fields->badSFX.begin(), m_fields->badSFX.end(), std::string(path)) == m_fields->badSFX.end();
-            bool isSettingDisabled = !config::get<bool>("player.muterewardssfx", false);
-            // these bools could be in one if statement but are separated for readability
-            if (isSettingDisabled || pauseLayerActive || isPlayerAlive || notFoundInBadSFX) { FMODAudioEngine::sharedEngine()->playEffect(path, p1, p2, p3); }
-        }
-    };
+		void playEffect(gd::string path, float p1, float p2, float p3) {
+			auto pl = PlayLayer::get();
+			if (!pl) { return FMODAudioEngine::sharedEngine()->playEffect(path, p1, p2, p3); } // play sfx if not in playlayer
+			bool isPlayerAlive = !pl->m_player1->m_isDead;
+			bool pauseLayerActive = cocos2d::CCDirector::get()->getRunningScene()->getChildByIDRecursive("PauseLayer");
+			bool notFoundInBadSFX = !m_fields->badSFX.contains(std::string(path));
+			bool isSettingDisabled = !config::get<bool>("player.muterewardssfx", false);
+			// these bools could be in one if statement but are separated for readability
+			if (isSettingDisabled || pauseLayerActive || isPlayerAlive || notFoundInBadSFX) { FMODAudioEngine::sharedEngine()->playEffect(path, p1, p2, p3); }
+		}
+	};
 
 }

--- a/src/hacks/Player/MuteRewardsSFX.cpp
+++ b/src/hacks/Player/MuteRewardsSFX.cpp
@@ -9,7 +9,6 @@ namespace eclipse::hacks::Player {
 
 	class MuteRewardsSFX : public hack::Hack {
 		void init() override {
-			config::setIfEmpty("player.muterewardssfx", false);
 			auto tab = gui::MenuTab::find("Player");
 			tab->addToggle("Mute Rewards SFX on Death", "player.muterewardssfx")
 				->setDescription("Disables all rewards SFX (orbs, diamonds, keys) when the player dies. (Created by RayDeeUx)")

--- a/src/hacks/Player/MuteRewardsSFX.cpp
+++ b/src/hacks/Player/MuteRewardsSFX.cpp
@@ -34,7 +34,7 @@ namespace eclipse::hacks::Player {
             bool isPlayerAlive = !pl->m_player1->m_isDead;
             bool pauseLayerActive = cocos2d::CCDirector::get()->getRunningScene()->getChildByIDRecursive("PauseLayer");
             bool notFoundInBadSFX = std::find(m_fields->badSFX.begin(), m_fields->badSFX.end(), std::string(path)) == m_fields->badSFX.end();
-            bool isSettingDisabled = !config::get<bool>("player.muterewardssfx");
+            bool isSettingDisabled = !config::get<bool>("player.muterewardssfx", false);
             // these bools could be in one if statement but are separated for readability
             if (isSettingDisabled || pauseLayerActive || isPlayerAlive || notFoundInBadSFX) { FMODAudioEngine::sharedEngine()->playEffect(path, p1, p2, p3); }
         }

--- a/src/hacks/Player/MuteRewardsSFX.cpp
+++ b/src/hacks/Player/MuteRewardsSFX.cpp
@@ -1,0 +1,40 @@
+#include <modules/gui/gui.hpp>
+#include <modules/hack/hack.hpp>
+#include <modules/config/config.hpp>
+
+#include <Geode/modify/FMODAudioEngine.hpp>
+
+namespace eclipse::hacks::Player {
+
+    class MuteRewardsSFX : public hack::Hack {
+        void init() override {
+            auto tab = gui::MenuTab::find("Player");
+            tab->addToggle("Mute Rewards SFX on Death", "player.muterewardssfx")->setDescription("Disables player death effect")->handleKeybinds();
+        }
+
+        [[nodiscard]] const char* getId() const override { return "Mute Rewards SFX on Death"; }
+    };
+
+    REGISTER_HACK(MuteRewardsSFX)
+
+    class $modify(FMODAudioEngine) {
+        struct Fields {
+            const std::list<std::string> badSFX = { "achievement_01.ogg", "magicExplosion.ogg", "gold02.ogg", "secretKey.ogg" };
+        };
+        static void onModify(auto& self) {
+            SAFE_PRIORITY("FMODAudioEngine::playEffect");
+        }
+
+        void playEffect(gd::string path, float p1, float p2, float p3) {
+            auto pl = PlayLayer::get();
+            if (!pl) { return FMODAudioEngine::sharedEngine()->playEffect(path, p1, p2, p3); } // play sfx if not in playlayer
+            bool isPlayerAlive = !pl->m_player1->m_isDead;
+            bool pauseLayerActive = cocos2d::CCDirector::get()->getRunningScene()->getChildByIDRecursive("PauseLayer");
+            bool notFoundInBadSFX = std::find(m_fields->badSFX.begin(), m_fields->badSFX.end(), std::string(path)) == m_fields->badSFX.end();
+            bool isSettingDisabled = !config::get<bool>("player.muterewardssfx");
+            // these bools could be in one if statement but are separated for readability
+            if (isSettingDisabled || pauseLayerActive || isPlayerAlive || notFoundInBadSFX) { FMODAudioEngine::sharedEngine()->playEffect(path, p1, p2, p3); }
+        }
+    };
+
+}

--- a/src/hacks/Player/NoPlatformerJumpSquish.cpp
+++ b/src/hacks/Player/NoPlatformerJumpSquish.cpp
@@ -8,7 +8,6 @@ namespace eclipse::hacks::Player {
 
 	class NoPlatformerJumpSquish : public hack::Hack {
 		void init() override {
-			config::setIfEmpty("player.noplatformersquish", false);
 			auto tab = gui::MenuTab::find("Player");
 			tab->addToggle("No Platformer Jump Squish", "player.noplatformersquish")
 				->setDescription("Disables the squishing animation when jumping in place while playing platformer levels. (Created by RayDeeUx)")

--- a/src/hacks/Player/NoPlatformerJumpSquish.cpp
+++ b/src/hacks/Player/NoPlatformerJumpSquish.cpp
@@ -8,9 +8,10 @@ namespace eclipse::hacks::Player {
 
     class NoPlatformerJumpSquish : public hack::Hack {
         void init() override {
+            config::setIfEmpty<bool>("player.noplatformersquish", false);
             auto tab = gui::MenuTab::find("Player");
             tab->addToggle("No Platformer Jump Squish", "player.noplatformersquish")
-                ->setDescription("Disables the squishing animation when jumping in place while playing platformer levels.")
+                ->setDescription("Disables the squishing animation when jumping in place while playing platformer levels. (Created by RayDeeUx)")
                 ->handleKeybinds();
         }
 
@@ -21,9 +22,8 @@ namespace eclipse::hacks::Player {
 
     class $modify(MyPlayerObject, PlayerObject){
         void animatePlatformerJump(float p0) {
-            if (!config::get<bool>("player.noplatformersquish")) {
-                PlayerObject::animatePlatformerJump(p0);
-            }
+            if (config::get<bool>("player.noplatformersquish", true)) { return; }
+            PlayerObject::animatePlatformerJump(p0);
         }
     };
 

--- a/src/hacks/Player/NoPlatformerJumpSquish.cpp
+++ b/src/hacks/Player/NoPlatformerJumpSquish.cpp
@@ -22,8 +22,9 @@ namespace eclipse::hacks::Player {
 
     class $modify(MyPlayerObject, PlayerObject){
         void animatePlatformerJump(float p0) {
-            if (config::get<bool>("player.noplatformersquish", true)) { return; }
-            PlayerObject::animatePlatformerJump(p0);
+            if (!config::get<bool>("player.noplatformersquish", false)) {
+                PlayerObject::animatePlatformerJump(p0);
+            }
         }
     };
 

--- a/src/hacks/Player/NoPlatformerJumpSquish.cpp
+++ b/src/hacks/Player/NoPlatformerJumpSquish.cpp
@@ -6,26 +6,25 @@
 
 namespace eclipse::hacks::Player {
 
-    class NoPlatformerJumpSquish : public hack::Hack {
-        void init() override {
-            config::setIfEmpty<bool>("player.noplatformersquish", false);
-            auto tab = gui::MenuTab::find("Player");
-            tab->addToggle("No Platformer Jump Squish", "player.noplatformersquish")
-                ->setDescription("Disables the squishing animation when jumping in place while playing platformer levels. (Created by RayDeeUx)")
-                ->handleKeybinds();
-        }
+	class NoPlatformerJumpSquish : public hack::Hack {
+		void init() override {
+			config::setIfEmpty("player.noplatformersquish", false);
+			auto tab = gui::MenuTab::find("Player");
+			tab->addToggle("No Platformer Jump Squish", "player.noplatformersquish")
+				->setDescription("Disables the squishing animation when jumping in place while playing platformer levels. (Created by RayDeeUx)")
+				->handleKeybinds();
+		}
 
-        [[nodiscard]] const char* getId() const override { return "No Platformer Jump Squish"; }
-    };
+		[[nodiscard]] const char* getId() const override { return "No Platformer Jump Squish"; }
+	};
 
-    REGISTER_HACK(NoPlatformerJumpSquish)
+	REGISTER_HACK(NoPlatformerJumpSquish)
 
-    class $modify(MyPlayerObject, PlayerObject){
-        void animatePlatformerJump(float p0) {
-            if (!config::get<bool>("player.noplatformersquish", false)) {
-                PlayerObject::animatePlatformerJump(p0);
-            }
-        }
-    };
+	class $modify(MyPlayerObject, PlayerObject){
+		void animatePlatformerJump(float p0) {
+			if (!config::get<bool>("player.noplatformersquish", false))
+				PlayerObject::animatePlatformerJump(p0);
+		}
+	};
 
 }

--- a/src/hacks/Player/NoPlatformerJumpSquish.cpp
+++ b/src/hacks/Player/NoPlatformerJumpSquish.cpp
@@ -1,0 +1,30 @@
+#include <modules/gui/gui.hpp>
+#include <modules/hack/hack.hpp>
+#include <modules/config/config.hpp>
+
+#include <Geode/modify/PlayerObject.hpp>
+
+namespace eclipse::hacks::Player {
+
+    class NoPlatformerJumpSquish : public hack::Hack {
+        void init() override {
+            auto tab = gui::MenuTab::find("Player");
+            tab->addToggle("No Platformer Jump Squish", "player.noplatformersquish")
+                ->setDescription("Disables the squishing animation when jumping in place while playing platformer levels.")
+                ->handleKeybinds();
+        }
+
+        [[nodiscard]] const char* getId() const override { return "No Platformer Jump Squish"; }
+    };
+
+    REGISTER_HACK(NoPlatformerJumpSquish)
+
+    class $modify(MyPlayerObject, PlayerObject){
+        void animatePlatformerJump(float p0) {
+            if (!config::get<bool>("player.noplatformersquish")) {
+                PlayerObject::animatePlatformerJump(p0);
+            }
+        }
+    };
+
+}


### PR DESCRIPTION
Previously from [ErysEdits](https://github.com/RayDeeUx/ErysEdits). Hopefully these five features make a dent in helping Eclipse Menu stand out from QOLMod.

* Mute Rewards SFX on Death
* Mute Level SFX
* Compact view for profile comments and editor levels
* No Platformer Jump Animation
* Hide "Level Complete" VFX

There's one other feature I want to add, but current FMODAudioEngine bindings make it difficult because of inlined bindings on Windows, and I'm not sure if platform-exclusive features are allowed here. (Am willing to make a separate PR otherwise.)

Some of these could be a bit more performant (especially with me hooking `PlayLayer::postUpdate()`), but the specific functions I'd need don't have memory addresses yet and are quite niche in their use case.