### PR TITLE
some Internal Recorder changes

### DIFF
--- a/src/hacks/Recorder/Recorder.cpp
+++ b/src/hacks/Recorder/Recorder.cpp
@@ -38,16 +38,15 @@ namespace eclipse::hacks::Recorder {
     cocos2d::CCSize newScreenScale;
 
     void callback(std::string const& error) {
-        Popup::create(
-            i18n::get_("common.error"),
-            error
-        );
+        geode::queueInMainThread([error] {
+            Popup::create(i18n::get_("common.error"), error);
+        });
     }
 
     void endPopup() {
         Popup::create(
             i18n::get_("common.info"),
-            i18n::get_("recorder.finished"),
+            i18n::format("recorder.finished", s_recorder.getRecordingDuration()),
             i18n::get_("common.ok"),
             i18n::get_("recorder.open-folder"),
             [](bool result) {
@@ -256,9 +255,7 @@ namespace eclipse::hacks::Recorder {
                 if (framerate < 1)
                     framerate = 1;
 
-                float tps = eclipse::config::get<"global.tpsbypass.toggle", bool>(false)
-                                ? eclipse::config::get<"global.tpsbypass", float>(240.f)
-                                : 240.f;
+                float tps = utils::getTPS();
 
                 dt = 1.f / framerate;
                 dt *= framerate / tps;

--- a/src/modules/recorder/DSPRecorder.cpp
+++ b/src/modules/recorder/DSPRecorder.cpp
@@ -30,6 +30,8 @@ void DSPRecorder::stop() {
     m_masterGroup->removeDSP(m_dsp);
     std::lock_guard lock(m_lock);
     m_recording = false;
+
+    m_masterGroup->setPaused(false);
 }
 
 std::vector<float> DSPRecorder::getData() {
@@ -70,7 +72,7 @@ void DSPRecorder::init() {
     system->getMasterChannelGroup(&m_masterGroup);
 }
 
-void DSPRecorder::tryUnpause(float time) {
+void DSPRecorder::tryUnpause(float time) const {
     auto system = eclipse::utils::get<FMODAudioEngine>()->m_system;
     int sampleRate;
     int channels;

--- a/src/modules/recorder/DSPRecorder.hpp
+++ b/src/modules/recorder/DSPRecorder.hpp
@@ -16,7 +16,7 @@ public:
 
     [[nodiscard]] bool isRecording() const { return m_recording; }
 
-    void tryUnpause(float time);
+    void tryUnpause(float time) const;
 
 private:
     void init();

--- a/src/modules/recorder/recorder.cpp
+++ b/src/modules/recorder/recorder.cpp
@@ -160,6 +160,9 @@ namespace eclipse::recorder {
                     break;
                 }
 
+                // break if we're not recording anymore (to avoid waiting forever)
+                if (!m_recording) break;
+
                 m_frameReady.set(false);
                 m_frameReady.wait_for(true);
             }

--- a/src/modules/recorder/recorder.hpp
+++ b/src/modules/recorder/recorder.hpp
@@ -3,8 +3,7 @@
 #include "ffmpeg-api/events.hpp"
 
 #include "rendertexture.hpp"
-
-#include <mutex>
+#include "spinlock.hpp"
 
 namespace eclipse::recorder {
     class Recorder {
@@ -29,10 +28,8 @@ namespace eclipse::recorder {
 
     private:
         bool m_recording = false;
-        bool m_frameHasData = false;
+        utils::spinlock m_frameReady;
         std::vector<uint8_t> m_currentFrame;
-        std::mutex m_lock;
-        std::condition_variable m_cv;
         RenderTexture m_renderTexture{};
         uint64_t m_recordingDuration = 0;
 

--- a/src/modules/recorder/recorder.hpp
+++ b/src/modules/recorder/recorder.hpp
@@ -15,6 +15,7 @@ namespace eclipse::recorder {
         void captureFrame();
 
         bool isRecording() const { return m_recording; }
+        std::string getRecordingDuration() const;
 
         void setCallback(const std::function<void(std::string const&)>& callback) { m_callback = callback; }
 
@@ -31,7 +32,9 @@ namespace eclipse::recorder {
         bool m_frameHasData = false;
         std::vector<uint8_t> m_currentFrame;
         std::mutex m_lock;
+        std::condition_variable m_cv;
         RenderTexture m_renderTexture{};
+        uint64_t m_recordingDuration = 0;
 
         std::function<void(std::string const&)> m_callback;
     };

--- a/src/modules/recorder/recorder.hpp
+++ b/src/modules/recorder/recorder.hpp
@@ -27,7 +27,7 @@ namespace eclipse::recorder {
         void recordThread();
 
     private:
-        bool m_recording = false;
+        volatile bool m_recording = false;
         utils::spinlock m_frameReady;
         std::vector<uint8_t> m_currentFrame;
         RenderTexture m_renderTexture{};

--- a/src/modules/recorder/rendertexture.cpp
+++ b/src/modules/recorder/rendertexture.cpp
@@ -1,63 +1,81 @@
 #include "rendertexture.hpp"
 
-#include <Geode/cocos/platform/win32/CCGL.h>
 #include <Geode/binding/PlayLayer.hpp>
+#include <Geode/cocos/platform/win32/CCGL.h>
 #include <modules/utils/SingletonCache.hpp>
 
 namespace eclipse::recorder {
     void RenderTexture::begin() {
-        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &m_old_fbo);
+        // Save the old FBO
+        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &m_oldFBO);
 
-        m_texture = new cocos2d::CCTexture2D;
-
-        {
-            std::unique_ptr<char, void(*)(void*)> data(static_cast<char*>(malloc(m_width * m_height * 4)), free);
-
-            memset(data.get(), 0, m_width * m_height * 4);
-            m_texture->initWithData(
-                data.get(),
-                cocos2d::kCCTexture2DPixelFormat_RGBA8888,
-                m_width, m_height,
-                cocos2d::CCSize(static_cast<float>(m_width), static_cast<float>(m_height))
-            );
+        // Create a new texture
+        constexpr auto bitsPerPixel = 32;
+        auto bytesPerRow = m_width * bitsPerPixel / 8;
+        if (bytesPerRow % 8 == 0) {
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 8);
+        } else if (bytesPerRow % 4 == 0) {
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+        } else if (bytesPerRow % 2 == 0) {
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 2);
+        } else {
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
         }
 
-        glGetIntegerv(GL_RENDERBUFFER_BINDING, &m_old_rbo);
+        glGenTextures(1, &m_texture);
+        glBindTexture(GL_TEXTURE_2D, m_texture);
 
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_width, m_height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+        // Save the old RBO
+        glGetIntegerv(GL_RENDERBUFFER_BINDING, &m_oldRBO);
+
+        // Create a new FBO
         glGenFramebuffers(1, &m_fbo);
         glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
 
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D, m_texture->getName(), 0);
+        // Attach the texture to the FBO
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
 
-        m_texture->setAliasTexParameters();
+        // Set texture parameters
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
-        glBindRenderbuffer(GL_RENDERBUFFER, m_old_rbo);
-        glBindFramebuffer(GL_FRAMEBUFFER, m_old_fbo);
+        // Unbind the FBO and RBO
+        glBindRenderbuffer(GL_RENDERBUFFER, m_oldRBO);
+        glBindFramebuffer(GL_FRAMEBUFFER, m_oldFBO);
     }
 
     void RenderTexture::end() const {
-        m_texture->release();
+        if (m_texture) glDeleteTextures(1, &m_texture);
+        if (m_fbo) glDeleteFramebuffers(1, &m_fbo);
     }
 
-    void RenderTexture::capture(std::mutex& lock, std::vector<uint8_t>& data, volatile bool& hasDataFlag) {
-        auto director = utils::get<cocos2d::CCDirector>();
-
+    void RenderTexture::capture(cocos2d::CCNode* node, std::span<uint8_t> buffer, std::mutex& lock, std::condition_variable& cv, volatile bool& hasDataFlag) {
         glViewport(0, 0, m_width, m_height);
 
-        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &m_old_fbo);
+        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &m_oldFBO);
         glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
 
+        auto director = utils::get<cocos2d::CCDirector>();
         director->setProjection(cocos2d::kCCDirectorProjectionCustom);
-        utils::get<PlayLayer>()->visit();
+        node->visit();
         director->setProjection(cocos2d::kCCDirectorProjection2D);
 
         glPixelStorei(GL_PACK_ALIGNMENT, 1);
-        lock.lock();
-        hasDataFlag = true;
-        glReadPixels(0, 0, m_width, m_height, GL_RGBA, GL_UNSIGNED_BYTE, data.data());
-        lock.unlock();
+        {
+            std::unique_lock l(lock);
+            glReadPixels(0, 0, m_width, m_height, GL_RGBA, GL_UNSIGNED_BYTE, buffer.data());
+            hasDataFlag = true;
+        }
+        cv.notify_one(); // calling notify_one() outside of the lock, to avoid locking the mutex twice
 
-        glBindFramebuffer(GL_FRAMEBUFFER, m_old_fbo);
+        glBindFramebuffer(GL_FRAMEBUFFER, m_oldFBO);
         director->setViewport();
     }
 }

--- a/src/modules/recorder/rendertexture.hpp
+++ b/src/modules/recorder/rendertexture.hpp
@@ -4,15 +4,20 @@
 
 namespace eclipse::recorder {
     class RenderTexture {
-    public:
-        uint32_t m_width, m_height;
-        int m_old_fbo, m_old_rbo;
-        uint32_t m_fbo;
-        cocos2d::CCTexture2D* m_texture;
+    protected:
+        uint32_t m_width = 0, m_height = 0;
+        GLint m_oldFBO = 0, m_oldRBO = 0;
+        GLuint m_fbo = 0;
+        GLuint m_texture = 0;
 
     public:
+        RenderTexture() = default;
+        RenderTexture(uint32_t width, uint32_t height) : m_width(width), m_height(height) {}
+        ~RenderTexture() { this->end(); }
+
         void begin();
         void end() const;
-        void capture(std::mutex& lock, std::vector<uint8_t>& data, volatile bool& hasDataFlag);
+
+        void capture(cocos2d::CCNode* node, std::span<uint8_t> buffer, std::mutex& lock, std::condition_variable& cv, volatile bool& hasDataFlag);
     };
 }

--- a/src/modules/recorder/rendertexture.hpp
+++ b/src/modules/recorder/rendertexture.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cocos2d.h>
+#include "spinlock.hpp"
 
 namespace eclipse::recorder {
     class RenderTexture {
@@ -18,6 +19,6 @@ namespace eclipse::recorder {
         void begin();
         void end() const;
 
-        void capture(cocos2d::CCNode* node, std::span<uint8_t> buffer, std::mutex& lock, std::condition_variable& cv, volatile bool& hasDataFlag);
+        void capture(cocos2d::CCNode* node, std::span<uint8_t> buffer, utils::spinlock& frameReady);
     };
 }

--- a/src/modules/recorder/spinlock.hpp
+++ b/src/modules/recorder/spinlock.hpp
@@ -21,6 +21,13 @@ namespace eclipse::utils {
             #endif
         }
 
+        /// @brief Checks the flag's state without locking the thread.
+        [[nodiscard]] bool read() const {
+            return m_flag.test(std::memory_order_acquire);
+        }
+
+        [[nodiscard]] operator bool() const { return read(); }
+
         /// @brief Sets the flag to the desired state and notifies any waiting threads.
         void set(bool state) {
             if (state) m_flag.test_and_set(std::memory_order_release);

--- a/src/modules/recorder/spinlock.hpp
+++ b/src/modules/recorder/spinlock.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+namespace eclipse::utils {
+    /// @brief A spinlock implementation that uses atomic_flag.
+    class spinlock {
+        // macOS doesn't support atomic wait yet :P
+        #if defined(__cpp_lib_atomic_wait) && __cpp_lib_atomic_wait >= 201907L
+        #define HAS_ATOMIC_WAIT 1
+        #else
+        #define HAS_ATOMIC_WAIT 0
+        #endif
+
+    public:
+        /// @brief Locks the thread until the flag is set to the desired state.
+        void wait_for(bool state) const {
+            #if HAS_ATOMIC_WAIT
+            m_flag.wait(!state, std::memory_order_acquire);
+            #else
+            while (m_flag.test(std::memory_order_acquire) != state)
+                std::this_thread::yield();
+            #endif
+        }
+
+        /// @brief Sets the flag to the desired state and notifies any waiting threads.
+        void set(bool state) {
+            if (state) m_flag.test_and_set(std::memory_order_release);
+            else m_flag.clear(std::memory_order_release);
+            #if HAS_ATOMIC_WAIT
+            m_flag.notify_one();
+            #endif
+        }
+
+    private:
+        std::atomic_flag m_flag = ATOMIC_FLAG_INIT;
+    };
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -161,8 +161,8 @@ namespace eclipse::utils {
     }
 
     float getTPS() {
-        if (!config::get("global.tpsbypass.toggle", false)) return 240;
-        return config::get("global.tpsbypass", 240.f);
+        return config::get<"global.tpsbypass.toggle", bool>(false)
+            ? config::get<"global.tpsbypass", float>(240.f) : 240.f;
     }
 
     cocos2d::CCMenu* getEclipseUILayer() {


### PR DESCRIPTION
Key changes:
- use a custom spinlock object (uses std::atomic_flag under the hood), instead of while loops and mutexes for better thread scheduling and code readability
- RenderTexture doesn't create cocos2d::CCTexture2D anymore and instead uses opengl calls manually
- fixes the cocos ui crash when triggering a callback
- error during recording should now stop the process
- recorder saves the rendering time it took and shows it to the user afterwards
- std::filesystem errors are now handled instead of throwing
- fix audio not unpausing after render finishes
- added a fix for UI triggers, so that objects are placed correctly when recording in a non-native resolution/aspect ratio
- add "Hide Preview" toggle, which makes the screen blank while rendering