### PR TITLE
legacy trail changes

### DIFF
--- a/src/hacks/Level/LegacyTrail.cpp
+++ b/src/hacks/Level/LegacyTrail.cpp
@@ -12,13 +12,13 @@ namespace eclipse::hacks::Level {
 
 			config::setIfEmpty("level.legacytrail", false);
 			config::setIfEmpty("level.legacytrail.force_max_points", false);
-			config::setIfEmpty("level.legacytrail.max_points", 15); // New config entry
+			config::setIfEmpty("level.legacytrail.max_points", 18); // New config entry
 
 			tab->addToggle("level.legacytrail")
 				->handleKeybinds()
 				->setDescription("Restore the trail effect from older versions.")
 				->addOptions([](std::shared_ptr<gui::MenuTab> options) {
-					options->addIntToggle("level.legacytrail.max_points", 10, 20);
+					options->addIntToggle("level.legacytrail.max_points", 2, 36);
 				});
 		}
 
@@ -31,43 +31,16 @@ namespace eclipse::hacks::Level {
 			ADD_HOOKS_DELEGATE("level.legacytrail");
 
 			bool initWithFade(float fade, float minSeg, float stroke, const cocos2d::ccColor3B& color, cocos2d::CCTexture2D* texture) {
-				this->setPosition({ .0f, .0f});
-				this->setAnchorPoint({ .0f, .0f});
-				this->ignoreAnchorPointForPosition(true);
-				m_bStartingPositionInitialized = false;
-
-				m_tPositionR = cocos2d::CCPoint{ .0f, .0f };
-				m_bFastMode = true;
-				m_fMinSeg = (minSeg == -1.f) ? stroke / 5.0f : minSeg;
-				m_fMinSeg *= m_fMinSeg;
-
-				m_fStroke = stroke;
-				m_fFadeDelta = 1.0f / fade;
+				if (!cocos2d::CCMotionStreak::initWithFade(fade, minSeg, stroke, color, texture))
+					return false;
 
 				float maxPoints = config::get<"level.legacytrail.max_points", float>();
 				m_uMaxPoints = static_cast<unsigned int>(maxPoints);
-
-				m_uNuPoints = 0;
-
-				m_pPointState = std::allocator<float>().allocate(sizeof(float) * m_uMaxPoints);
-				m_pPointVertexes = std::allocator<cocos2d::CCPoint>().allocate(sizeof(cocos2d::CCPoint) * m_uMaxPoints);
-
-				m_pVertices = std::allocator<cocos2d::ccVertex2F>().allocate(sizeof(cocos2d::ccVertex2F) * m_uMaxPoints * 2);
-				m_pTexCoords = std::allocator<cocos2d::ccTex2F>().allocate(sizeof(cocos2d::ccTex2F) * m_uMaxPoints * 2);
-				m_pColorPointer = std::allocator<GLubyte>().allocate(sizeof(GLubyte) * m_uMaxPoints * 2 * 4);
-
-				m_tBlendFunc.src = GL_SRC_ALPHA;
-				m_tBlendFunc.dst = GL_ONE_MINUS_SRC_ALPHA;
 
 				auto program = eclipse::utils::get<cocos2d::CCShaderCache>()->programForKey(
 					kCCShader_PositionTextureColor
 				);
 				this->setShaderProgram(program);
-
-				this->setTexture(texture);
-				this->setColor(color);
-
-				this->scheduleUpdate();
 
 				return true;
 			}

--- a/src/modules/utils/GameCheckpoint.hpp
+++ b/src/modules/utils/GameCheckpoint.hpp
@@ -175,7 +175,7 @@ namespace eclipse::utils {
             m_lastGroundedPos = player->m_lastGroundedPos;
             m_lastActivatedPortal = player->m_lastActivatedPortal;
             m_hasEverJumped = player->m_hasEverJumped;
-            m_ringOrStreakRelated = player->m_ringOrStreakRelated;
+            // m_ringOrStreakRelated = player->m_ringOrStreakRelated;
             m_playerColor1 = player->m_playerColor1;
             m_playerColor2 = player->m_playerColor2;
             m_isSecondPlayer = player->m_isSecondPlayer;
@@ -438,7 +438,7 @@ namespace eclipse::utils {
             player->m_lastGroundedPos = m_lastGroundedPos;
             player->m_lastActivatedPortal = m_lastActivatedPortal;
             player->m_hasEverJumped = m_hasEverJumped;
-            player->m_ringOrStreakRelated = m_ringOrStreakRelated;
+            // player->m_ringOrStreakRelated = m_ringOrStreakRelated;
             player->m_playerColor1 = m_playerColor1;
             player->m_playerColor2 = m_playerColor2;
             player->m_isSecondPlayer = m_isSecondPlayer;
@@ -703,7 +703,7 @@ namespace eclipse::utils {
         cocos2d::CCPoint m_lastGroundedPos;
         GameObject* m_lastActivatedPortal;
         bool m_hasEverJumped;
-        bool m_ringOrStreakRelated;
+        // bool m_ringOrStreakRelated;
         cocos2d::ccColor3B m_playerColor1;
         cocos2d::ccColor3B m_playerColor2;
         bool m_isSecondPlayer;


### PR DESCRIPTION
removed unnecessary code

changed default points from 15 to 18 to avoid cutting even on 60hz. also updated the point range to 2 to 36. this is possible because i removed the manual memory allocation

still works pretty much the same

also commented out m_ringOrStreakRelated because its not a member of PlayerObject, at least not in geode 4.4.0 i guess