### PR TITLE
fix(StartPosSwitcher): don't trigger `PlayLayer::resetCamera()` manually

### DIFF
--- a/src/hacks/Level/StartPosSwitcher.cpp
+++ b/src/hacks/Level/StartPosSwitcher.cpp
@@ -224,12 +224,13 @@ namespace eclipse::hacks::Level {
         }
 
         void resetLevel() {
-            auto spSwitcherMod = config::get<bool>("level.startpos_switcher", true);
-            auto spSwitcherResetCameraMod = config::get<bool>("level.startpos_switcher.reset_camera", true);
-            if (spSwitcherMod && spSwitcherResetCameraMod) {
-                for (StartPosObject* obj : startPosObjects)
-                     obj->m_startSettings->m_resetCamera = true;
+            if (!config::get<"level.startpos_switcher", bool>() || !config::get<"level.startpos_switcher.reset_camera", bool>()) {
+                PlayLayer::resetLevel();
+                return;
             }
+
+            for (auto* obj : startPosObjects)
+                obj->m_startSettings->m_resetCamera = true;
 
             PlayLayer::resetLevel();
         }

--- a/src/hacks/Level/StartPosSwitcher.cpp
+++ b/src/hacks/Level/StartPosSwitcher.cpp
@@ -224,11 +224,14 @@ namespace eclipse::hacks::Level {
         }
 
         void resetLevel() {
-            PlayLayer::resetLevel();
+            auto spSwitcherMod = config::get<bool>("level.startpos_switcher", true);
+            auto spSwitcherResetCameraMod = config::get<bool>("level.startpos_switcher.reset_camera", true);
+            if (spSwitcherMod && spSwitcherResetCameraMod) {
+                for (StartPosObject* obj : startPosObjects)
+                     obj->m_startSettings->m_resetCamera = true;
+            }
 
-            // Reset camera
-            if (currentStartPosIndex >= 0 && config::get<bool>("level.startpos_switcher.reset_camera", true))
-                this->resetCamera();
+            PlayLayer::resetLevel();
         }
 
         void addObject(GameObject* object) {


### PR DESCRIPTION
`reset_camera` was very buggy if you played in practice. You can check what I mean with `119731730`; if you place a checkpoint after 12%, and you die you just get randomly teleported outside the map.

With this patch, `reset_camera` is applied directly to the startpos instead of manually triggering a `PlayLayer::resetCamera()`, which makes all these problems disappear.

This also fixes `level.startpos_switcher.reset_camera` being enabled, despite `level.startpos_switcher` being disabled (debugging this was hell, because I wasn't expecting this to be the case...)