### PR TITLE
fix path unlocker also unlocking all other GJItems

### DIFF
--- a/src/hacks/Bypass/PathsUnlocker.cpp
+++ b/src/hacks/Bypass/PathsUnlocker.cpp
@@ -30,7 +30,7 @@ namespace eclipse::hacks::Cosmetic {
         bool isItemUnlocked(UnlockType type, int key) {
             if (GameStatsManager::isItemUnlocked(type, key)) return true;
 
-            if (type == UnlockType::GJItem && (key >= 6 || key <= 15))
+            if (type == UnlockType::GJItem && (key >= 6 && key <= 15))
                 return config::get<"bypass.unlockpaths", bool>(false);
 
             return false;


### PR DESCRIPTION
why did it check if key is >= 6 OR <=15
thats always gonna be true