### PR TITLE
Fix MSVC compile error

### DIFF
--- a/src/modules/gui/color.hpp
+++ b/src/modules/gui/color.hpp
@@ -119,7 +119,7 @@ namespace eclipse::gui {
             static HSL fromColor(Color const& color);
             static Color toColor(HSL const& hsl);
 
-            constexpr operator Color() const { return toColor(*this); }
+            operator Color() const { return toColor(*this); }
         };
 
         [[nodiscard]] HSL toHSL() const;


### PR DESCRIPTION
stops this error:
path with eclipse\EclipseMenu-geode-v5\EclipseMenu-geode-v5\src\modules\gui\color.hpp(122,23): error C3615: constexpr functi on 'eclipse::gui::Color::HSL::operator eclipse::gui::Color' cannot result in a constant expression [path with eclipse\Eclips eMenu-geode-v5\EclipseMenu-geode-v5\build\EclipseMenu.vcxproj] with MSVC

(this might just be me so here is what is being used: geode 5.0.0-beta.3 ofc and "MSBuild version 17.14.40+3e7442088 for .NET Framework")