### PR TITLE
Change accurate percentage to show the progressbar more accurately

### DIFF
--- a/src/hacks/Level/AccuratePercentage.cpp
+++ b/src/hacks/Level/AccuratePercentage.cpp
@@ -59,8 +59,8 @@ namespace eclipse::hacks::Global {
                 if (!config::get<"level.accuratepercentage.bugfix", bool>(true)) return;
                 m_progressFill->setTextureRect({
                     0, 0,
-                    (m_progressBar->getTextureRect().getMaxX() - 4) * percent / 100.f,
-                    m_progressBar->getTextureRect().getMaxY() / 2
+                    m_progressWidth * percent / 100.f,
+                    m_progressHeight
                 });
             }
         }


### PR DESCRIPTION
Vanilla GD hardcodes the progress fill to be 4.0 units smaller than the progress bar itself, and it stores the full dimensions of the fill as `m_progressWidth` and `m_progressHeight`. Eclipse does not use either of those variables and hardcodes the wrong offset of 5.0 units, due to which I ran into a small visual bug in Globed (I use a correct offset, so my drawn green line is ahead of the progress fill when it shouldn't be)
<img width="139" height="84" alt="image" src="https://github.com/user-attachments/assets/7dd78d8e-edee-4f2f-9eec-f8d6d6c57305" />
