### PR TITLE
Disable safe mode if on testmode/startpositions (Disable on StartPos)

### DIFF
--- a/src/hacks/Global/SafeMode.cpp
+++ b/src/hacks/Global/SafeMode.cpp
@@ -113,7 +113,7 @@ namespace eclipse::hacks::Global {
             tab->addToggle("global.autosafemode")->handleKeybinds()->setDescription()->addOptions([](auto options) {
                 options->addToggle("global.autosafemode.warn-popup")->setDescription();
                 options->addToggle("Disable on StartPos", "global.autosafemode.disable-on-startpos")
-                    ->setDescription("Disables safe mode when you are playing from a start position --miskaa");
+                    ->setDescription("Disables safe mode when you are playing from a start position\n(Created by miskaa)");
             });
         }
 

--- a/src/hacks/Global/SafeMode.cpp
+++ b/src/hacks/Global/SafeMode.cpp
@@ -45,8 +45,17 @@ namespace eclipse::hacks::Global {
             });
         }
 
+        static bool amionstartpos() {
+            auto* playLayer = utils::get<PlayLayer>();
+            if (!playLayer) return false;
+            return playLayer->m_isTestMode;
+        }
+
         static bool shouldEnable() {
             if (!config::get<bool>("global.autosafemode", false))
+                return false;
+
+            if (amionstartpos())
                 return false;
 
             return s_trippedLastAttempt || hasCheats();

--- a/src/hacks/Global/SafeMode.cpp
+++ b/src/hacks/Global/SafeMode.cpp
@@ -55,7 +55,7 @@ namespace eclipse::hacks::Global {
             if (!config::get<bool>("global.autosafemode", false))
                 return false;
 
-            if (amionstartpos())
+            if (config::get<bool>("global.autosafemode.disable-on-startpos", true) && amionstartpos())
                 return false;
 
             return s_trippedLastAttempt || hasCheats();
@@ -108,9 +108,12 @@ namespace eclipse::hacks::Global {
 
             config::setIfEmpty("global.autosafemode", true);
             config::setIfEmpty("global.autosafemode.warn-popup", true);
+            config::setIfEmpty("global.autosafemode.disable-on-startpos", true);
 
             tab->addToggle("global.autosafemode")->handleKeybinds()->setDescription()->addOptions([](auto options) {
                 options->addToggle("global.autosafemode.warn-popup")->setDescription();
+                options->addToggle("Disable on StartPos", "global.autosafemode.disable-on-startpos")
+                    ->setDescription("Disables safe mode when you are playing from a start position --miskaa");
             });
         }
 


### PR DESCRIPTION
allows people to get more attempts if they are practicing a level with speedhack/noclip if they accidentally left auto safe mode on